### PR TITLE
Delimit if/else branches with braces instead of \else

### DIFF
--- a/trunk/fc-french.def
+++ b/trunk/fc-french.def
@@ -1644,15 +1644,21 @@ z\'ero%
       \count0=0 % 
     \fi
     \ifnum\count0=1 %
+        \expandafter\@firstoftwo
+    \else
+        \expandafter\@secondoftwo
+    \fi
 %    \end{macrocode}
 % \changes{3.01}{2014-11-10}{Protect \cs{`}, for solving
 % \uref{http://github.com/nlct/fmtcount/issues/15}{Issue \#15}}
 %    \begin{macrocode}
+        {%
       \protected@edef\@tempa{\expandafter\fc@wcase\fc@first\@nil}%
-    \else
+        }%
 %    \end{macrocode}
 % Now we tamper a little bit with the plural handling options to ensure that there is no final plural mark.
 %    \begin{macrocode}
+        {%
       \def\@tempa##1{%
         \expandafter\edef\csname fc@frenchoptions@##1@plural\endcsname{%
           \ifcase\csname fc@frenchoptions@##1@plural\endcsname\space
@@ -1715,7 +1721,7 @@ z\'ero%
           \fi
         \fi
       \fi
-    \fi
+  }%
 %    \end{macrocode}
 % Apply \cs{fc@gcase} to the result.
 %    \begin{macrocode}


### PR DESCRIPTION
When `cleveref 0.21.4` is loaded together with `fmtcount` 3.05 with the french language, e.g with
```
\documentclass[12pt,french]{article}
\usepackage{babel}
\usepackage{cleveref}
\usepackage{fmtcount}
\begin{document}
\ordinalstringnum{1}
\end{document}
```
the result is
```
Incomplete \ifnum; all text was ignored after line ...
```
This is probably due to a command like `\@tempa` or similar that cleveref redefines to `\iftrue` or `\iffalse` somewhere for its usage, which leads the fast conditional skipping of TeX astray. Use braced arguments and `\@firstoftwo`/`\@secondoftwo` instead, which fixes the problem.